### PR TITLE
Avoid float degradation

### DIFF
--- a/lib/fast-polylines/decoder.rb
+++ b/lib/fast-polylines/decoder.rb
@@ -20,13 +20,13 @@ module FastPolylines
       end
       lat = lng = 0
       coords.each_slice(2).map do |coords_pair|
-        lat += decode_number(coords_pair[0], precision)
-        lng += decode_number(coords_pair[1], precision)
-        [lat, lng]
+        lat += decode_number(coords_pair[0])
+        lng += decode_number(coords_pair[1])
+        [lat / precision, lng / precision]
       end
     end
 
-    def self.decode_number(string, precision = 1e5)
+    def self.decode_number(string)
       result = 1
       shift = 0
       string.each_byte do |b|
@@ -34,8 +34,7 @@ module FastPolylines
         result += b << shift
         shift += 5
       end
-      result = (result & 1).nonzero? ? (~result >> 1) : (result >> 1)
-      result / precision
+      (result & 1).nonzero? ? (~result >> 1) : (result >> 1)
     end
     private_class_method :decode_number
   end

--- a/spec/fast-polylines/decoder_spec.rb
+++ b/spec/fast-polylines/decoder_spec.rb
@@ -28,5 +28,12 @@ describe FastPolylines::Decoder do
         expect(described_class.decode("krk{FdxdlO?e@")).to eq points
       end
     end
+    context "with points that cause float overflow" do
+      let(:polyline) { "ahdiHsmeMHPDN|A`FVt@" }
+      let(:points) { [[48.85137, 2.32682], [48.85132, 2.32673], [48.85129, 2.32665], [48.85082, 2.32552], [48.8507, 2.32525]] }
+      it "should respect precision" do
+        expect(described_class.decode(polyline)).to eq points
+      end
+    end
   end
 end


### PR DESCRIPTION
Some polylines can create an issue on float precision. For instance, the polyline ```ahdiHsmeMHPDN|A`FVt@``` gives the next result:

```ruby
[[48.85137, 2.32682]
 [48.85132, 2.32673],
 [48.85129, 2.32665],
 [48.85082, 2.32552],
 [48.850699999999996, 2.32525]] # Some kind of precision overflow...
```

There is a simple way around it, and it is to use integer until the last moment. And thus avoid float computation.

---

This kind of overflow comes from floating point math:

```ruby
puts 0.1 + 0.2 # 0.30000000000000004
```

You can see more about this [here](https://stackoverflow.com/q/588004/6320039).