### PR TITLE
Use correct chunk comparison

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# This gives debug output in the C code and some debugger flags, useful for... Debugging.
+# See ext/fast_polylines/extconf.rb
+DEBUG = # 1
 EXT_NAME = fast_polylines
 RUBY_FLAG = -I lib:ext -r $(EXT_NAME)
 ALL_TARGETS = $(wildcard ext/$(EXT_NAME)/*.c) $(wildcard ext/$(EXT_NAME)/*.h)
@@ -8,7 +11,7 @@ console: ext
 
 .PHONY: test
 test: ext
-	bundle exec rspec $(RUBY_FLAG) spec
+	bundle exec rspec
 
 .PHONY: rubocop
 rubocop:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Implementation of the [Google polyline algorithm][algorithm].
 
-**BREAKING CHANGES:** The version 2.0.0 of FastPolylines includes breaking changes, see [Migrate from 1.0.0](#migrate-from-100)
+**BREAKING CHANGES:** The version 2 of FastPolylines includes breaking changes, see [Migrate from V1](#migrate-from-V1)
 
 
 About **300x faster encoding and decoding**  than [Joshua Clayton's gem][polylines].
@@ -16,35 +16,35 @@ About **300x faster encoding and decoding**  than [Joshua Clayton's gem][polylin
 ——————————————————————————————— ENCODING ————————————————————————————————
 
 Warming up --------------------------------------
-           Polylines   277.000  i/100ms
-     FastPolylinesV1     2.050k i/100ms
-     FastPolylinesV2    73.822k i/100ms
+           Polylines   310.000  i/100ms
+     FastPolylinesV1     2.607k i/100ms
+     FastPolylinesV2    59.833k i/100ms
 Calculating -------------------------------------
-           Polylines      3.254k (± 1.8%) i/s -     16.343k in   5.023767s
-     FastPolylinesV1     25.715k (± 3.7%) i/s -    129.150k in   5.029675s
-     FastPolylinesV2    933.751k (± 4.3%) i/s -      4.725M in   5.072446s
+           Polylines      2.957k (± 5.9%) i/s -     14.880k in   5.049867s
+     FastPolylinesV1     25.644k (± 5.8%) i/s -    127.743k in   4.999954s
+     FastPolylinesV2    682.981k (± 7.7%) i/s -      3.410M in   5.025952s
 
 Comparison:
-     FastPolylinesV2:   933750.7 i/s
-     FastPolylinesV1:    25715.1 i/s - 36.31x  slower
-           Polylines:     3254.3 i/s - 286.93x  slower
+     FastPolylinesV2:   682980.7 i/s
+     FastPolylinesV1:    25643.7 i/s - 26.63x  slower
+           Polylines:     2957.1 i/s - 230.97x  slower
 
 
 ———————————————————————————————  DECODING ————————————————————————————————
 
 Warming up --------------------------------------
-           Polylines   140.000  i/100ms
-     FastPolylinesV1     1.602k i/100ms
-     FastPolylinesV2    36.432k i/100ms
+           Polylines   127.000  i/100ms
+     FastPolylinesV1     1.225k i/100ms
+     FastPolylinesV2    40.667k i/100ms
 Calculating -------------------------------------
-           Polylines      1.401k (± 2.2%) i/s -      7.000k in   5.000321s
-     FastPolylinesV1     16.465k (± 3.7%) i/s -     83.304k in   5.067786s
-     FastPolylinesV2    396.100k (± 5.2%) i/s -      2.004M in   5.074500s
+           Polylines      1.289k (± 6.1%) i/s -      6.477k in   5.046552s
+     FastPolylinesV1     15.445k (± 4.4%) i/s -     77.175k in   5.006896s
+     FastPolylinesV2    468.413k (± 7.8%) i/s -      2.359M in   5.068936s
 
 Comparison:
-     FastPolylinesV2:   396100.0 i/s
-     FastPolylinesV1:    16464.6 i/s - 24.06x  slower
-           Polylines:     1400.6 i/s - 282.81x  slower
+     FastPolylinesV2:   468412.8 i/s
+     FastPolylinesV1:    15445.4 i/s - 30.33x  slower
+           Polylines:     1288.8 i/s - 363.46x  slower
 ```
 
 ## Install
@@ -84,7 +84,7 @@ FastPolylines.decode("_izlhA~rlgdF_{geC~ywl@_kwzCn`{nI", 6)
 ```
 The precision max is `13`.
 
-## Migrate from 1.0.0
+## Migrate from V1
 
 **TL;DR:**
 

--- a/ext/fast_polylines/extconf.rb
+++ b/ext/fast_polylines/extconf.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
 
 require "mkmf"
+
+if ENV["DEBUG"]
+  warn "DEBUG MODE."
+  $CFLAGS << " " << %w(
+    -Wall
+    -ggdb
+    -DDEBUG
+    -pedantic
+  ) * " "
+end
 create_makefile "fast_polylines/fast_polylines"

--- a/ext/fast_polylines/fast_polylines.c
+++ b/ext/fast_polylines/fast_polylines.c
@@ -72,15 +72,18 @@ rb_FastPolylines__decode(int argc, VALUE *argv, VALUE self) {
 
 static inline uint8_t
 _polyline_encode_number(char *chunks, int64_t number) {
+	dbg("_polyline_encode_number(\"%s\", %lli)\n", chunks, number);
 	number = number < 0 ? ~(number << 1) : (number << 1);
 	uint8_t i = 0;
-	while (number > 0x20) {
+	while (number >= 0x20) {
 		uint8_t chunk = number & 0x1f;
 		chunks[i++] = (0x20 | chunk) + 63;
 		number = number >> 5;
 	}
-	dbg("%u encoded chunks\n", i);
 	chunks[i++] = number + 63;
+	dbg("%u encoded chunks\n", i);
+	dbg("chunks: %s\n", chunks);
+	dbg("/_polyline_encode_number");
 	return i;
 }
 
@@ -108,6 +111,7 @@ rb_FastPolylines__encode(int argc, VALUE *argv, VALUE self) {
 	for (i = 0; i < len; i++) {
 			current_pair = RARRAY_AREF(argv[0], i);
 			uint8_t j;
+			Check_Type(current_pair, T_ARRAY);
 			if (RARRAY_LEN(current_pair) != 2) {
 				free(chunks);
 				rb_raise(rb_eArgError, "wrong number of coordinates");
@@ -136,6 +140,7 @@ rb_FastPolylines__encode(int argc, VALUE *argv, VALUE self) {
 				// We pass a pointer to the current chunk that need to be filled. Doing so
 				// avoid having to copy the string every single iteration.
 				chunks_index += _polyline_encode_number(chunks + chunks_index * sizeof(char), delta);
+				dbg("%s\n", chunks);
 			}
 	}
 	dbg("final chunks_index: %zu\n", chunks_index);

--- a/spec/fast_polylines_spec.rb
+++ b/spec/fast_polylines_spec.rb
@@ -1,10 +1,8 @@
-require "spec_helper"
-
 describe FastPolylines do
   describe ".decode" do
     let(:points) { [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]] }
+    let(:polyline) { "_p~iF~ps|U_ulLnnqC_mqNvxq`@" }
     context "with default precision" do
-      let(:polyline) { "_p~iF~ps|U_ulLnnqC_mqNvxq`@" }
       it "should decode a polyline correctly" do
         expect(described_class.decode(polyline)).to eq points
       end
@@ -47,9 +45,34 @@ describe FastPolylines do
   end
 
   describe ".encode" do
-    let(:points)   { [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]] }
+    let(:points) { [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]] }
+    let(:polyline) { "_p~iF~ps|U_ulLnnqC_mqNvxq`@" }
+    it "should raise for invalid input" do
+      expect { described_class.encode(points[0]) }.to raise_error(
+        TypeError,
+        "wrong argument type Float (expected Array)"
+      )
+      expect { described_class.encode([points]) }.to raise_error(
+        ArgumentError,
+        "wrong number of coordinates"
+      )
+      expect { described_class.encode([points[0..1]]) }.to raise_error(
+        TypeError,
+        "no implicit conversion to Float from Array"
+      )
+    end
+    # The method `_polyline_encode_number("", 16)` will check for a chunk
+    # of the size 32, which is the chunk size limit. This was errored due to
+    # a bad sign.
+    # Reported in issue #15, closed in PR #16
+    context "with points close to the chunk size limit" do
+      let(:points) { [[0, 0.00016]] }
+      let(:polyline) { "?_@" }
+      it "should encode points correctly" do
+        expect(described_class.encode(points)).to eq polyline
+      end
+    end
     context "with default precision" do
-      let(:polyline) { "_p~iF~ps|U_ulLnnqC_mqNvxq`@" }
       it "should encode points correctly" do
         expect(described_class.encode(points)).to eq polyline
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 require "rubygems"
 require "bundler/setup"
 
+$LOAD_PATH.unshift File.join(__dir__, "..", "lib")
+$LOAD_PATH.unshift File.join(__dir__, "..", "ext")
+
 require "fast_polylines"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Fixes #15

Also in this pull request:
- Add more debugging information in C
- Add security for bad inputs such as
  ```ruby
  FastPolylines.encode([1.2, 1.2])
  ```

The security part slows down a tiny bit the `FastPolylines.encode`
method. However it avoids a core dump.