### PR TITLE
Simplify bundle require

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ rvm:
   - 2.6
   - 2.7
 script: make test
+cache: bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- A Require ptah that match the gem name (#18)
+
 ### Changed
 
 ### Fixed

--- a/fast-polylines.gemspec
+++ b/fast-polylines.gemspec
@@ -14,10 +14,9 @@ Gem::Specification.new do |spec|
   spec.license     = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.4.6")
 
-  spec.files = `git ls-files -- {lib,ext}/*`.split("\n")
-  spec.files += ["README.md"]
+  spec.files = Dir["{lib,ext}/**/*.{rb,c}"] + %w(README.md CHANGELOG.md)
   spec.extensions = ["ext/fast_polylines/extconf.rb"]
-  spec.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
+  spec.test_files =Dir["spec/**/*"] + %w(.rspec)
   spec.require_paths = "lib"
 
   spec.add_development_dependency("benchmark-ips", "~> 2.7")

--- a/lib/fast-polylines.rb
+++ b/lib/fast-polylines.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+# Allow both snake_case and kebab-case way to require
+require_relative "fast_polylines"

--- a/spec/fast-polylines_spec.rb
+++ b/spec/fast-polylines_spec.rb
@@ -1,0 +1,10 @@
+require "fast-polylines"
+
+describe FastPolylines do
+  let(:points) { [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]] }
+  let(:polyline) { "_p~iF~ps|U_ulLnnqC_mqNvxq`@" }
+  it "should work with kebab-case requirement" do
+    expect(FastPolylines.encode(points)).to eq polyline
+    expect(FastPolylines.decode(polyline)).to eq points
+  end
+end

--- a/spec/fast_polylines_spec.rb
+++ b/spec/fast_polylines_spec.rb
@@ -1,3 +1,5 @@
+require "fast_polylines"
+
 describe FastPolylines do
   describe ".decode" do
     let(:points) { [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]] }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,6 @@ require "bundler/setup"
 $LOAD_PATH.unshift File.join(__dir__, "..", "lib")
 $LOAD_PATH.unshift File.join(__dir__, "..", "ext")
 
-require "fast_polylines"
-
 RSpec.configure do |config|
   # Additional config goes here
 end


### PR DESCRIPTION
Closes #17. Allow both `kebab-case` and `snake_case` for `require`, fixing bundle related issues. 