### PR TITLE
Speedup calculation by avoiding calling pow(10,x)

### DIFF
--- a/ext/fast_polylines/fast_polylines.c
+++ b/ext/fast_polylines/fast_polylines.c
@@ -26,14 +26,17 @@
 
 typedef unsigned int uint;
 
-// Speed up the code a bit by not calling pow(10.0, precision) since it's always 10^precision
-// Convert that into a lookup instead of doing the calculation
-const double PRECISION_VALUES[MAX_PRECISION+2] = {1.0, 10.0, 1.0e+2, 1.0e+3, 1.0e+4, 1.0e+5, 1.0e+6, 1.0e+7, 1.0e+8, 1.0e+9, 1.0e+10, 1.0e+11, 1.0e+12, 1.0e+13, 1.0e+14};
-static inline double fast_pow10(uint);
-
-// uint precision is already checked earlier to ensure that it's within the range
-static inline double fast_pow10(uint precision) {
-	return PRECISION_VALUES[precision];
+// Speed up the code a bit by not calling pow(10.0, precision) since it is
+// always 10^precision. Convert that into a lookup instead of doing the
+// calculation.
+// The precision parameter is already checked in +_get_precision()+ to ensure
+// that it is within the range.
+static inline double _fast_pow10(uint precision) {
+	const double lookup[MAX_PRECISION + 1] = {
+		1.0, 10.0, 1.0e+2, 1.0e+3, 1.0e+4, 1.0e+5, 1.0e+6, 1.0e+7,
+		1.0e+8, 1.0e+9, 1.0e+10, 1.0e+11, 1.0e+12, 1.0e+13
+	};
+	return lookup[precision];
 }
 
 static inline uint _get_precision(VALUE value) {
@@ -49,7 +52,7 @@ rb_FastPolylines__decode(int argc, VALUE *argv, VALUE self) {
 	Check_Type(argv[0], T_STRING);
 	char* polyline = StringValueCStr(argv[0]);
 	uint precision = _get_precision(argc > 1 ? argv[1] : Qnil);
-	double precision_value = fast_pow10(precision);
+	double precision_value = _fast_pow10(precision);
 
 	VALUE ary = rb_ary_new();
 	// Helps keeping track of whether we are computing lat (0) or lng (1).
@@ -111,7 +114,7 @@ rb_FastPolylines__encode(int argc, VALUE *argv, VALUE self) {
 	uint precision = _get_precision(argc > 1 ? argv[1] : Qnil);
 	dbg("rb_FastPolylines__encode(..., %u)\n", precision);
 	rdbg(argv[0]);
-	double precision_value = fast_pow10(precision);
+	double precision_value = _fast_pow10(precision);
 
 	// This is the maximum possible size the polyline may have. This
 	// being **without** null character. To copy it later as a Ruby


### PR DESCRIPTION
This is a small change that removes the need to call pow(10, x) which is an expensive operation and replaces it with a simple lookup to speed up the running.

On my computer, it is approx 10% ~ 40% quicker on the benchmark compared to fast_polyline v2.1.0