### PR TITLE
Improve makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,48 @@
+# Begin OS detection
+ifeq ($(OS),Windows_NT) # is Windows_NT on XP, 2000, 7, Vista, 10...
+    OPERATING_SYSTEM := Windows
+    PATH_SEPARATOR := ;
+else
+    OPERATING_SYSTEM := $(shell uname)  # same as "uname -s"
+	PATH_SEPARATOR := :
+endif
+
 # This gives debug output in the C code and some debugger flags, useful for... Debugging.
 # See ext/fast_polylines/extconf.rb
 DEBUG = # 1
 EXT_NAME = fast_polylines
-RUBY_FLAG = -I lib:ext -r $(EXT_NAME)
+RUBY_FLAG = -I lib$(PATH_SEPARATOR)ext -r $(EXT_NAME)
 ALL_TARGETS = $(wildcard ext/$(EXT_NAME)/*.c) $(wildcard ext/$(EXT_NAME)/*.h)
 
+##@ Utility
+
+FMT_TITLE='\\033[7\;1m'
+FMT_PRIMARY='\\033[36m'
+FMT_END='\\033[0m'
+.PHONY: help
+help: ## Shows this help menu.
+	@printf -- "                               FAST-POLYLINES\n"
+	@printf -- "---------------------------------------------------------------------------\n"
+	@awk ' \
+			BEGIN {FS = ":.*##"; printf "Usage: make ${FMT_PRIMARY}<target>${FMT_END}\n"} \
+	    	/^[a-zA-Z0-9_-]+:.*?##/ { printf "  $(FMT_PRIMARY)%-30s$(FMT_END) %s\n", $$1, $$2 } \
+			/^##@/ { printf "\n$(FMT_TITLE) %s $(FMT_END)\n", substr($$0, 5) } \
+		' $(MAKEFILE_LIST)
+
 .PHONY: console
-console: ext
+console: ext ## Runs an irb console with fast-polylines
 	irb $(RUBY_FLAG)
 
 .PHONY: test
-test: ext
+test: ext ## Runs tests
 	bundle exec rspec
 
 .PHONY: rubocop
-rubocop:
+rubocop: ## Checks ruby syntax
 	bundle exec rubocop
 
 .PHONY: benchmark
-benchmark: ext
+benchmark: ext ## Run the benchmark
 	bundle exec ruby $(RUBY_FLAG) ./perf/benchmark.rb
 
 ext/$(EXT_NAME)/Makefile: ext/$(EXT_NAME)/extconf.rb
@@ -27,10 +51,12 @@ ext/$(EXT_NAME)/Makefile: ext/$(EXT_NAME)/extconf.rb
 ext/$(EXT_NAME)/$(EXT_NAME).bundle: ext/$(EXT_NAME)/Makefile $(ALL_TARGETS)
 	make -C ext/$(EXT_NAME)
 
+##@ C extension
+
 .PHONY: ext
-ext: ext/$(EXT_NAME)/$(EXT_NAME).bundle
+ext: ext/$(EXT_NAME)/$(EXT_NAME).bundle ## Compiles the C extension
 
 .PHONY: clean
-clean:
+clean: ## Cleans C stuff
 	cd ext/$(EXT_NAME) && make clean
 	rm ext/$(EXT_NAME)/Makefile


### PR DESCRIPTION
Greatly improved by [timberio/vector]'s makefile.

- Add Windows detection.
- Fix ruby loadpath option.
- Add a `make help` utility.

Fixes #21

[timberio/vector]: https://github.com/timberio/vector