### PR TITLE
Remove explicit type check when encoding

### DIFF
--- a/ext/fast_polylines/fast_polylines.c
+++ b/ext/fast_polylines/fast_polylines.c
@@ -135,17 +135,6 @@ rb_FastPolylines__encode(int argc, VALUE *argv, VALUE self) {
 			}
 			for (j = 0; j < 2; j++) {
 				VALUE current_value =	RARRAY_AREF(current_pair, j);
-				switch (TYPE(current_value)) {
-					case T_BIGNUM:
-					case T_FLOAT:
-					case T_FIXNUM:
-					case T_RATIONAL:
-						break;
-					default:
-						free(chunks);
-						rb_raise(rb_eTypeError, "no implicit conversion to Float from %s", rb_obj_classname(current_value));
-				};
-
 				double parsed_value = NUM2DBL(current_value);
 				if (-180.0 > parsed_value || parsed_value > 180.0) {
 					free(chunks);

--- a/spec/fast_polylines_spec.rb
+++ b/spec/fast_polylines_spec.rb
@@ -60,7 +60,7 @@ describe FastPolylines do
       )
       expect { described_class.encode([points[0..1]]) }.to raise_error(
         TypeError,
-        "no implicit conversion to Float from Array"
+        "can't convert Array into Float"
       )
     end
     # The method `_polyline_encode_number("", 16)` will check for a chunk


### PR DESCRIPTION
Current checks restricts to only a few types and raise errors with other types of `Numeric`. (e.g. `BigDecimal`)
It also seems like `NUM2DBL` will do some type-checking and raise `TypeError` https://webwallet.reddcoin.com/mri/source/object.c?v=2.3.8#3034
