### PR TITLE
Add API documentation (targetting rubydoc.info mostly)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.gem
 .rubocop-*
 Gemfile.lock
+/.yardoc
+/yardoc
+*.bundle

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--markup markdown
+--output-dir ./yardoc
+lib/**/*.rb
+ext/**/*.c
+-
+README.md
+CHANGELOG.md

--- a/ext/fast_polylines/fast_polylines.c
+++ b/ext/fast_polylines/fast_polylines.c
@@ -1,3 +1,24 @@
+/**
+ * Document-module: FastPolylines
+ *
+ * Implementation of the [Google polyline algorithm](https://code.google.com/apis/maps/documentation/utilities/polylinealgorithm.html).
+ *
+ * Install it with `gem install fast-polylines`, and then:
+ *
+ *     require "fast_polylines"
+ *
+ *     FastPolylines.encode([[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]])
+ *     # "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+ *
+ *     FastPolylines.decode("_p~iF~ps|U_ulLnnqC_mqNvxq`@")
+ *     # [[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]]
+ *
+ * You can set an arbitrary precision for your coordinates to be encoded/decoded. It may be from 1
+ * to 13 decimal digits. However, 13 may be too much.
+ *
+ * [![https://xkcd.com/2170/](https://imgs.xkcd.com/comics/coordinate_precision.png)](https://www.explainxkcd.com/wiki/index.php/2170:_Coordinate_Precision)
+ */
+
 #include <ruby.h>
 
 // An encoded number can have at most _precision_ characters. However,
@@ -46,7 +67,15 @@ static inline uint _get_precision(VALUE value) {
 	return (uint)precision;
 }
 
-static inline VALUE
+/**
+ * call-seq:
+ *   FastPolylines.decode(polyline, precision = 5) -> [[lat, lng], ...]
+ *
+ * Decode a polyline to a list of coordinates (lat, lng tuples). You may
+ * set an arbitrary coordinate precision, however, it **must match** the precision
+ * that was used for encoding.
+ */
+static VALUE
 rb_FastPolylines__decode(int argc, VALUE *argv, VALUE self) {
 	rb_check_arity(argc, 1, 2);
 	Check_Type(argv[0], T_STRING);
@@ -103,7 +132,15 @@ _polyline_encode_number(char *chunks, int64_t number) {
 	return i;
 }
 
-static inline VALUE
+/**
+ * call-seq:
+ *   FastPolylines.encode([[lat, lng], ...], precision = 5) -> string
+ *
+ * Encode a list of coordinates to a polyline, you may give a specific precision
+ * if you want to retain more (or less) than 5 digits of precision. The maximum
+ * is 13, and may really be [too much](https://xkcd.com/2170/).
+ */
+static VALUE
 rb_FastPolylines__encode(int argc, VALUE *argv, VALUE self) {
 	rb_check_arity(argc, 1, 2);
 	Check_Type(argv[0], T_ARRAY);

--- a/fast-polylines.gemspec
+++ b/fast-polylines.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{lib,ext}/**/*.{rb,c}"] + %w(README.md CHANGELOG.md)
   spec.extensions = ["ext/fast_polylines/extconf.rb"]
-  spec.test_files =Dir["spec/**/*"] + %w(.rspec)
+  spec.test_files = Dir["spec/**/*"] + %w(.rspec)
   spec.require_paths = "lib"
 
   spec.add_development_dependency("benchmark-ips", "~> 2.7")

--- a/lib/fast_polylines.rb
+++ b/lib/fast_polylines.rb
@@ -3,17 +3,19 @@
 require "fast_polylines/fast_polylines"
 
 module FastPolylines::Encoder
+  # @deprecated Use {FastPolylines.encode} instead.
   module_function def encode(points, precision = 1e5)
     warn "Deprecated use of `FastPolylines::Encoder.encode`, " \
-          "use `FastPolylines.encode`."
+         "use `FastPolylines.encode`."
     FastPolylines.encode(points, Math.log10(precision))
   end
 end
 
 module FastPolylines::Decoder
+  # @deprecated Use {FastPolylines.decode} instead.
   module_function def decode(polyline, precision = 1e5)
     warn "Deprecated use of `FastPolylines::Decoder.decode`, " \
-          "use `FastPolylines.decode`."
+         "use `FastPolylines.decode`."
     FastPolylines.decode(polyline, Math.log10(precision))
   end
 end


### PR DESCRIPTION
Currently writing an article on C extensions, I saw that we miss correct documentation here (https://rubydoc.info/gems/fast-polylines). I've wrote some documentation, mostly targetting the C extension to both provide an example for the article and improve our doc :)

You can preview it with `yard && python3 -m http.server -d yardoc 1234`

Once merged, we'll be able to test that on rubydoc.info with https://rubydoc.info/github/klaxit/fast-polylines/eeec3d4